### PR TITLE
cirrus: Adapt for new neutron-clang release approach

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ kernel_task:
       - sed -i '/E_ROOT/d' /usr/bin/makepkg
       - sed -i "s/PKGEXT='.pkg.tar.xz'/PKGEXT='.pkg.tar.zst'/" /etc/makepkg.conf
       - echo 'COMPRESSZST+=(--threads=0)' >> /etc/makepkg.conf
-      - git clone https://gitlab.com/dakkshesh07/neutron-clang -b Neutron-16 --depth=1
+      - mkdir neutron-clang && cd neutron-clang && bash <(curl -s https://raw.githubusercontent.com/Neutron-Toolchains/antman/main/antman) -S && cd ..
 
   build_script:
       - env ci=y makepkg -s && curl -s https://bin.cyberknight777.dev/vkZQ/raw | bash


### PR DESCRIPTION
The new approach makes use of AntMan (A Nonsensical Toolchain Manager). AntMan is a toolchain manager written in bash that can be used to download/sync toolchain builds, update them, and manage them.

AntMan-repo: https://github.com/Neutron-Toolchains/antman
Migration-commit: Neutron-Toolchains/clang-build@7dfd33d